### PR TITLE
Travis Timeout Increased

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
   fi
 script:
 - |
-  travis_wait 40 $(npm bin)/cypress run --record --key $CYPRESS_KEY \
+  travis_wait 59 $(npm bin)/cypress run --record --key $CYPRESS_KEY \
   --project ./fourfront/deploy/post_deploy_testing \
   --env Auth0Client=$Auth0Client,Auth0Secret=$Auth0Secret \
   --config baseUrl=$CYPRESS_BASE_URL


### PR DESCRIPTION
**Problem**:Some recent cypress tests logs "The spec started, but never completed" message and terminated without fully running all tests. A fix in time-out configuration may solve the problem since 

1. Travis Job logs as : **Timeout (40 minutes) reached**. ` Terminating "/home/travis/build/4dn-dcic/post-deploy-cypress-tests/node_modules/.bin/cypress run --record --key [secure] --project ...`
2. .travis.yml, defines the timeout period as: `travis_wait 40 $(npm bin)/cypress run --record --key $CYPRESS_KEY \ ...` 
3. the latest tests lasts around 30-40 minutes with recent configuration, and exceeding of 40 minutes timeout is ordinary.

**Solution**: Travis wait time is increased to 59.
